### PR TITLE
Move ID request note

### DIFF
--- a/lib/pause_2017/templates/public/request_id/_form.html.ep
+++ b/lib/pause_2017/templates/public/request_id/_form.html.ep
@@ -1,6 +1,11 @@
 % my $pause = stash(".pause") || {};
 % my $alt = 0;
 
+<p>A PAUSE account is only required to distribute and manage Perl module
+distributions on CPAN. You do not need a PAUSE account to submit
+bug reports to <a href="http://rt.cpan.org/">RT</a> or participate
+in many Perl community sites.</p>
+
 <div class="alternate<%= $alt++ % 2 + 1 %>">
 <p><b>Your full name (civil name)</b></p>
 <p><small>Unicode Characters OK.</small></p>

--- a/lib/pause_2017/templates/public/request_id/request.html.ep
+++ b/lib/pause_2017/templates/public/request_id/request.html.ep
@@ -1,11 +1,6 @@
 % layout 'layout';
 % my $pause = stash(".pause") || {};
 
-<p>A PAUSE account is only required to distribute and manage Perl module
-distributions on CPAN. You do not need a PAUSE account to submit
-bug reports to <a href="http://rt.cpan.org/">RT</a> or participate
-in many Perl community sites.</p>
-
 % if (@{$pause->{errors} || []}) {
 <h3>Error processing form</h3>
 %   for (@{$pause->{errors}}) {


### PR DESCRIPTION
This moves the "You don't need a PAUSE ID..." note to the form template
so it doesn't show up on the accepted registration page.